### PR TITLE
Set default to blank for filter dropdown selectors

### DIFF
--- a/Affordable-Housing/src/app/search/search-list/search-list.component.html
+++ b/Affordable-Housing/src/app/search/search-list/search-list.component.html
@@ -11,7 +11,7 @@
                 </div>
                 I am Looking for...
                 <div class="mt-3 flex">
-                    
+
                     <input type="radio" value="Apartment" style="margin-right:10px; margin-left: 150px;"><label
                         style="margin-right:50px">Apartment</label>
                     <input type="radio" value="House" style="margin-right:10px"><label
@@ -101,6 +101,7 @@
                             focus:border-indigo-500
                             sm:text-sm
                             ">
+                            <option></option>
                             <option>Less than $1000</option>
                             <option>$1001 - $1500</option>
                             <option>$1501-$2000</option>
@@ -121,6 +122,7 @@
                             focus:border-indigo-500
                             sm:text-sm
                             ">
+                            <option></option>
                             <option>Less than $100</option>
                             <option>$101 - $150</option>
                             <option>$151 - $200</option>
@@ -141,6 +143,7 @@
                             focus:border-indigo-500
                             sm:text-sm
                             ">
+                            <option></option>
                             <option>Studio</option>
                             <option>1</option>
                             <option>2</option>
@@ -161,6 +164,7 @@
                             focus:border-indigo-500
                             sm:text-sm
                             ">
+                            <option></option>
                             <option>1</option>
                             <option>2</option>
                             <option>2 1/2</option>
@@ -181,6 +185,7 @@
                             focus:border-indigo-500
                             sm:text-sm
                             ">
+                            <option></option>
                             <option>Bikini Bottom Apartments</option>
                             <option>123 Elmo Street</option>
                             <option>9876 Kidney Lane</option>


### PR DESCRIPTION
Set Defaults for the advanced search filter options that are dropdown boxes to empty.